### PR TITLE
add support config number of replicas setting

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -23,9 +23,9 @@ default['elasticsearch']['node_member'] = true
 default['elasticsearch']['cluster_name'] = "elasticsearch"
 default['elasticsearch']['member_hosts'] = []
 
-# Prevent unassigned shard replication in single node mode
-# Override this if you have two or more elasticsearch node
-default['elasticsearch']['index_number_of_replicas'] = 0
+# Explicitly set number of replicas, override this as necessary
+# Also you need to explicitly include `elasticsearch_set_replica` recipe
+default['elasticsearch']['index_number_of_replicas'] = 3
 
 # Java package to install by platform
 default['elasticsearch']['java'] = {

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -23,6 +23,10 @@ default['elasticsearch']['node_member'] = true
 default['elasticsearch']['cluster_name'] = "elasticsearch"
 default['elasticsearch']['member_hosts'] = []
 
+# Prevent unassigned shard replication in single node mode
+# Override this if you have two or more elasticsearch node
+default['elasticsearch']['index_number_of_replicas'] = 0
+
 # Java package to install by platform
 default['elasticsearch']['java'] = {
   'centos' => 'java-1.8.0-openjdk-headless',

--- a/recipes/elasticsearch.rb
+++ b/recipes/elasticsearch.rb
@@ -11,6 +11,3 @@
 include_recipe "#{cookbook_name}::elasticsearch_install"
 include_recipe "#{cookbook_name}::elasticsearch_user"
 include_recipe "#{cookbook_name}::elasticsearch_config"
-include_recipe "#{cookbook_name}::elasticsearch_systemd"
-
-

--- a/recipes/elasticsearch.rb
+++ b/recipes/elasticsearch.rb
@@ -11,3 +11,4 @@
 include_recipe "#{cookbook_name}::elasticsearch_install"
 include_recipe "#{cookbook_name}::elasticsearch_user"
 include_recipe "#{cookbook_name}::elasticsearch_config"
+include_recipe "#{cookbook_name}::elasticsearch_systemd"

--- a/recipes/elasticsearch_config.rb
+++ b/recipes/elasticsearch_config.rb
@@ -83,3 +83,30 @@ end
 link '/usr/share/elasticsearch/config' do
   to '/etc/elasticsearch/'
 end
+
+# Start elasticsearch
+include_recipe "#{cookbook_name}::elasticsearch_systemd"
+
+number_of_replicas = node['elasticsearch']['index_number_of_replicas']
+
+# Since ES >= 5, index configuration cannot using yaml file, using dynamic config API instead
+
+# Create default template which will used by future indices with default number_of_replicas
+http_request 'Create default template' do
+  url "http://#{node.ipaddress}:#{port}/_template/default"
+  action :put
+  headers "Content-Type" => "application/json"
+  message "{ \"index_patterns\": [\"*\"], \"order\": -1, \"settings\": { \"number_of_replicas\": \"#{number_of_replicas}\" }}"
+  retry_delay 30
+  retries 10
+end
+
+# Update old index, might be error because new node have empty index, ignored
+http_request 'Change number_of_replicas in existing index' do
+  url "http://#{node.ipaddress}:#{port}/_settings"
+  action :put
+  headers "Content-Type" => "application/json"
+  message "{ \"number_of_replicas\" : \"#{number_of_replicas}\" }"
+  retry_delay 30
+  ignore_failure true
+end

--- a/recipes/elasticsearch_config.rb
+++ b/recipes/elasticsearch_config.rb
@@ -6,8 +6,6 @@
 #
 #
 
-
-
 Chef::Recipe.send(:include, HostProperties)
 hostname = node.hostname
 port = node['elasticsearch']['port']
@@ -82,31 +80,4 @@ end
 
 link '/usr/share/elasticsearch/config' do
   to '/etc/elasticsearch/'
-end
-
-# Start elasticsearch
-include_recipe "#{cookbook_name}::elasticsearch_systemd"
-
-number_of_replicas = node['elasticsearch']['index_number_of_replicas']
-
-# Since ES >= 5, index configuration cannot using yaml file, using dynamic config API instead
-
-# Create default template which will used by future indices with default number_of_replicas
-http_request 'Create default template' do
-  url "http://#{node.ipaddress}:#{port}/_template/default"
-  action :put
-  headers "Content-Type" => "application/json"
-  message "{ \"index_patterns\": [\"*\"], \"order\": -1, \"settings\": { \"number_of_replicas\": \"#{number_of_replicas}\" }}"
-  retry_delay 30
-  retries 10
-end
-
-# Update old index, might be error because new node have empty index, ignored
-http_request 'Change number_of_replicas in existing index' do
-  url "http://#{node.ipaddress}:#{port}/_settings"
-  action :put
-  headers "Content-Type" => "application/json"
-  message "{ \"number_of_replicas\" : \"#{number_of_replicas}\" }"
-  retry_delay 30
-  ignore_failure true
 end

--- a/recipes/elasticsearch_set_replica.rb
+++ b/recipes/elasticsearch_set_replica.rb
@@ -1,12 +1,13 @@
 #
 # Cookbook:: elasticsearchwrapper
-# Recipe:: elasticsearch_config
+# Recipe:: elasticsearch_set_replica
 #
 # Copyright:: 2018, BaritoLog.
 #
 #
 
 number_of_replicas = node['elasticsearch']['index_number_of_replicas']
+port = node['elasticsearch']['port']
 
 # Since ES >= 5, index configuration cannot using yaml file, using dynamic config API instead
 

--- a/recipes/elasticsearch_set_replica.rb
+++ b/recipes/elasticsearch_set_replica.rb
@@ -1,0 +1,31 @@
+#
+# Cookbook:: elasticsearchwrapper
+# Recipe:: elasticsearch_config
+#
+# Copyright:: 2018, BaritoLog.
+#
+#
+
+number_of_replicas = node['elasticsearch']['index_number_of_replicas']
+
+# Since ES >= 5, index configuration cannot using yaml file, using dynamic config API instead
+
+# Create default template which will used by future indices with default number_of_replicas
+http_request 'Create default template' do
+  url "http://#{node.ipaddress}:#{port}/_template/default"
+  action :put
+  headers "Content-Type" => "application/json"
+  message "{ \"index_patterns\": [\"*\"], \"order\": -1, \"settings\": { \"number_of_replicas\": \"#{number_of_replicas}\" }}"
+  retry_delay 30
+  retries 10
+end
+
+# Update old index, might be error because new node have empty index, ignored
+http_request 'Change number_of_replicas in existing index' do
+  url "http://#{node.ipaddress}:#{port}/_settings"
+  action :put
+  headers "Content-Type" => "application/json"
+  message "{ \"number_of_replicas\" : \"#{number_of_replicas}\" }"
+  retry_delay 30
+  ignore_failure true
+end


### PR DESCRIPTION
- add `index_number_of_replicas configuration`
- since Elasticsearch version 5 and above not support index configuration in yaml file, need using dynamic configuration using REST API